### PR TITLE
Allow running the script with a non-default `bash`

### DIFF
--- a/bin/diktat
+++ b/bin/diktat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # vim:ai et sw=4 si sta ts=4:
 #


### PR DESCRIPTION
This makes sense on Mac OS X, where `/bin/bash` is an outdated Bash 3, and people tend to use Bash 4+ from Homebrew instead.